### PR TITLE
BREAKING CHANGE: move namespace and project name to Haipa

### DIFF
--- a/src/CloudInit.ConfigDrive.Abstractions/CloudInit.ConfigDrive.Abstractions.csproj
+++ b/src/CloudInit.ConfigDrive.Abstractions/CloudInit.ConfigDrive.Abstractions.csproj
@@ -2,18 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <RootNamespace>Contiva.CloudInit.ConfigDrive</RootNamespace>
-    <AssemblyName>Contiva.CloudInit.ConfigDrive.Abstractions</AssemblyName>
+    <AssemblyName>Haipa.CloudInit.ConfigDrive.Abstractions</AssemblyName>
+    <RootNamespace>Haipa.CloudInit.ConfigDrive</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://github.com/contiva/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/contiva/CloudInit.ConfigDrive</PackageProjectUrl>
-    <Copyright>Contiva</Copyright>
-    <Authors>Contiva</Authors>
-    <Company>Contiva</Company>
-    <Product>Contiva.CloudInit.ConfigDrive</Product>
-    <RepositoryUrl>https://github.com/contiva/CloudInit.ConfigDrive</RepositoryUrl>
-
+    <PackageLicenseUrl>https://github.com/haipa/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/haipa/CloudInit.ConfigDrive</PackageProjectUrl>
+    <Copyright>Haipa Project</Copyright>
+    <Authors>Haipa Project</Authors>
+    <Company>Haipa Project</Company>
+    <Product>Haipa.CloudInit.ConfigDrive</Product>
+    <RepositoryUrl>https://github.com/haipa/CloudInit.ConfigDrive</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudInit.ConfigDrive.Abstractions/Generator/IGenerateableBuilder.cs
+++ b/src/CloudInit.ConfigDrive.Abstractions/Generator/IGenerateableBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive.Generator
+﻿namespace Haipa.CloudInit.ConfigDrive.Generator
 {
     public interface IGenerateableBuilder : IBuilder
     {

--- a/src/CloudInit.ConfigDrive.Abstractions/IBuilder.cs
+++ b/src/CloudInit.ConfigDrive.Abstractions/IBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive
+﻿namespace Haipa.CloudInit.ConfigDrive
 {
     public interface IBuilder
     {

--- a/src/CloudInit.ConfigDrive.Abstractions/ICommandHandler.cs
+++ b/src/CloudInit.ConfigDrive.Abstractions/ICommandHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive
+﻿namespace Haipa.CloudInit.ConfigDrive
 {
     public interface ICommandHandler<T>
     {

--- a/src/CloudInit.ConfigDrive.Abstractions/IConfigDriveGenerator.cs
+++ b/src/CloudInit.ConfigDrive.Abstractions/IConfigDriveGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive
+﻿namespace Haipa.CloudInit.ConfigDrive
 {
     public interface IConfigDriveGenerator
     {

--- a/src/CloudInit.ConfigDrive.Abstractions/Injection/IResolutionContext.cs
+++ b/src/CloudInit.ConfigDrive.Abstractions/Injection/IResolutionContext.cs
@@ -3,7 +3,7 @@
 
 using System.Collections;
 
-namespace Contiva.CloudInit.ConfigDrive.Injection
+namespace Haipa.CloudInit.ConfigDrive.Injection
 {
     /// <summary>
     /// Represents the context of resolving one root service and can be used throughout the tree to fetch something to be injected

--- a/src/CloudInit.ConfigDrive.Abstractions/Processing/IProcessableBuilder.cs
+++ b/src/CloudInit.ConfigDrive.Abstractions/Processing/IProcessableBuilder.cs
@@ -1,6 +1,4 @@
-﻿using Contiva.CloudInit.ConfigDrive.Generator;
-
-namespace Contiva.CloudInit.ConfigDrive.Processing
+﻿namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     public interface IProcessableBuilder : IBuilder
     {

--- a/src/CloudInit.ConfigDrive.Core/BaseBuilder.cs
+++ b/src/CloudInit.ConfigDrive.Core/BaseBuilder.cs
@@ -1,7 +1,6 @@
-﻿using Contiva.CloudInit.ConfigDrive.Generator;
-using Contiva.CloudInit.ConfigDrive.Injection;
+﻿using Haipa.CloudInit.ConfigDrive.Injection;
 
-namespace Contiva.CloudInit.ConfigDrive
+namespace Haipa.CloudInit.ConfigDrive
 {
     public class BaseBuilder: IBuilder
     {

--- a/src/CloudInit.ConfigDrive.Core/CloudInit.ConfigDrive.Core.csproj
+++ b/src/CloudInit.ConfigDrive.Core/CloudInit.ConfigDrive.Core.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <RootNamespace>Contiva.CloudInit.ConfigDrive</RootNamespace>
-    <AssemblyName>Contiva.CloudInit.ConfigDrive.Core</AssemblyName>
+    <AssemblyName>Haipa.CloudInit.ConfigDrive.Core</AssemblyName>
+    <RootNamespace>Haipa.CloudInit.ConfigDrive</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://github.com/contiva/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/contiva/CloudInit.ConfigDrive</PackageProjectUrl>
-    <Copyright>Contiva</Copyright>
-    <Authors>Contiva</Authors>
-    <Company>Contiva</Company>
-    <Product>Contiva.CloudInit.ConfigDrive</Product>
-    <RepositoryUrl>https://github.com/contiva/CloudInit.ConfigDrive</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/haipa/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/haipa/CloudInit.ConfigDrive</PackageProjectUrl>
+    <Copyright>Haipa Project</Copyright>
+    <Authors>Haipa Project</Authors>
+    <Company>Haipa Project</Company>
+    <Product>Haipa.CloudInit.ConfigDrive</Product>
+    <RepositoryUrl>https://github.com/haipa/CloudInit.ConfigDrive</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudInit.ConfigDrive.Core/CloudInitConfigurationException.cs
+++ b/src/CloudInit.ConfigDrive.Core/CloudInitConfigurationException.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-#if NET45
 using System.Runtime.Serialization;
+#if NET45
+
 #elif NETSTANDARD2_0
 using System.Runtime.Serialization;
 #endif
 
-namespace Contiva.CloudInit.ConfigDrive
+namespace Haipa.CloudInit.ConfigDrive
 {
 #if NET45
     [Serializable]

--- a/src/CloudInit.ConfigDrive.Core/ConfigDriveContent.cs
+++ b/src/CloudInit.ConfigDrive.Core/ConfigDriveContent.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Contiva.CloudInit.ConfigDrive
+namespace Haipa.CloudInit.ConfigDrive
 {
     public class ConfigDriveContent
     {

--- a/src/CloudInit.ConfigDrive.Core/ConfigDriveProxySettings.cs
+++ b/src/CloudInit.ConfigDrive.Core/ConfigDriveProxySettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive
+﻿namespace Haipa.CloudInit.ConfigDrive
 {
     public struct ConfigDriveProxySettings
     {

--- a/src/CloudInit.ConfigDrive.Core/DummyCommandHandler.cs
+++ b/src/CloudInit.ConfigDrive.Core/DummyCommandHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive
+﻿namespace Haipa.CloudInit.ConfigDrive
 {
     public class DummyCommandHandler<T> : ICommandHandler<T>
     {

--- a/src/CloudInit.ConfigDrive.Core/Generator/GeneratableBuilder.cs
+++ b/src/CloudInit.ConfigDrive.Core/Generator/GeneratableBuilder.cs
@@ -1,6 +1,6 @@
-﻿using Contiva.CloudInit.ConfigDrive.Injection;
+﻿using Haipa.CloudInit.ConfigDrive.Injection;
 
-namespace Contiva.CloudInit.ConfigDrive.Generator
+namespace Haipa.CloudInit.ConfigDrive.Generator
 {
     public class GenerateableBuilder : BaseBuilder, IGenerateableBuilder
     {

--- a/src/CloudInit.ConfigDrive.Core/Generator/GenerateResultCommand.cs
+++ b/src/CloudInit.ConfigDrive.Core/Generator/GenerateResultCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive.Generator
+﻿namespace Haipa.CloudInit.ConfigDrive.Generator
 {
     public class GenerateResultCommand
     {

--- a/src/CloudInit.ConfigDrive.Core/Injection/Injectionist.cs
+++ b/src/CloudInit.ConfigDrive.Core/Injection/Injectionist.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.Injection
+namespace Haipa.CloudInit.ConfigDrive.Injection
 {
     /// <summary>
     /// Dependency injectionist that can be used for configuring a system of injected service implementations, possibly with decorators,

--- a/src/CloudInit.ConfigDrive.Core/Injection/ResolutionException.cs
+++ b/src/CloudInit.ConfigDrive.Core/Injection/ResolutionException.cs
@@ -2,13 +2,14 @@
 // source: https://raw.githubusercontent.com/rebus-org/Rebus/master/Rebus/Injection/ResolutionException.cs
 
 using System;
-#if NET45
 using System.Runtime.Serialization;
+#if NET45
+
 #elif NETSTANDARD2_0
 using System.Runtime.Serialization;
 #endif
 
-namespace Contiva.CloudInit.ConfigDrive.Injection
+namespace Haipa.CloudInit.ConfigDrive.Injection
 {
     /// <summary>
     /// Exceptions that is thrown when something goes wrong while working with the injectionist

--- a/src/CloudInit.ConfigDrive.Core/Injection/ResolutionResult.cs
+++ b/src/CloudInit.ConfigDrive.Core/Injection/ResolutionResult.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections;
 
-namespace Contiva.CloudInit.ConfigDrive.Injection
+namespace Haipa.CloudInit.ConfigDrive.Injection
 {
     /// <summary>
     /// Contains a built object instance along with all the objects that were used to build the instance

--- a/src/CloudInit.ConfigDrive.Core/Processing/CallbackProcessResultCommandHandlerDecoration.cs
+++ b/src/CloudInit.ConfigDrive.Core/Processing/CallbackProcessResultCommandHandlerDecoration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Contiva.CloudInit.ConfigDrive.Processing
+namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     internal class CallbackProcessResultCommandHandlerDecoration : ICommandHandler<ProcessResultCommand>
     {

--- a/src/CloudInit.ConfigDrive.Core/Processing/ProcessResultCommand.cs
+++ b/src/CloudInit.ConfigDrive.Core/Processing/ProcessResultCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive.Processing
+﻿namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     public class ProcessResultCommand
     {

--- a/src/CloudInit.ConfigDrive.Core/Processing/ProcessorBuilder.cs
+++ b/src/CloudInit.ConfigDrive.Core/Processing/ProcessorBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Contiva.CloudInit.ConfigDrive.Generator;
+using Haipa.CloudInit.ConfigDrive.Generator;
 
-namespace Contiva.CloudInit.ConfigDrive.Processing
+namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     public class ProcessorBuilder : GenerateableBuilder
     {

--- a/src/CloudInit.ConfigDrive.Core/ResultFile.cs
+++ b/src/CloudInit.ConfigDrive.Core/ResultFile.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace Contiva.CloudInit.ConfigDrive
+namespace Haipa.CloudInit.ConfigDrive
 {
     public class ResultFile
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/CloudInit.ConfigDrive.NoCloud.csproj
+++ b/src/CloudInit.ConfigDrive.NoCloud/CloudInit.ConfigDrive.NoCloud.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <AssemblyName>Contiva.CloudInit.ConfigDrive.NoCloud</AssemblyName>
-    <RootNamespace>Contiva.CloudInit.ConfigDrive</RootNamespace>
+    <AssemblyName>Haipa.CloudInit.ConfigDrive.NoCloud</AssemblyName>
+    <RootNamespace>Haipa.CloudInit.ConfigDrive</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://github.com/contiva/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/contiva/CloudInit.ConfigDrive</PackageProjectUrl>
-    <Copyright>Contiva</Copyright>
-    <Authors>Contiva</Authors>
-    <Company>Contiva</Company>
-    <Product>Contiva.CloudInit.ConfigDrive</Product>
-    <RepositoryUrl>https://github.com/contiva/CloudInit.ConfigDrive</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/haipa/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/haipa/CloudInit.ConfigDrive</PackageProjectUrl>
+    <Copyright>Haipa Project</Copyright>
+    <Authors>Haipa Project</Authors>
+    <Company>Haipa Project</Company>
+    <Product>Haipa.CloudInit.ConfigDrive</Product>
+    <RepositoryUrl>https://github.com/haipa/CloudInit.ConfigDrive</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateContentConfigCommandHandlerDecorator.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateContentConfigCommandHandlerDecorator.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateContentConfigCommandHandlerDecorator : ICommandHandler<GenerateUserDataCommand>
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateMetaDataCommand.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateMetaDataCommand.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateMetaDataCommand
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateMetaDataCommandHandler.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateMetaDataCommandHandler.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateMetaDataCommandHandler : ICommandHandler<GenerateMetaDataCommand>
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateNetworkDataCommand.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateNetworkDataCommand.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateNetworkDataCommand
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateNetworkDataCommandHandler.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateNetworkDataCommandHandler.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateNetworkDataCommandHandler : ICommandHandler<GenerateNetworkDataCommand>
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateProxyConfigCommandHandlerDecorator.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateProxyConfigCommandHandlerDecorator.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text;
 using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateProxyConfigCommandHandlerDecorator : ICommandHandler<GenerateUserDataCommand>
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateSwapConfigCommandHandlerDecorator.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateSwapConfigCommandHandlerDecorator.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateSwapConfigCommandHandlerDecorator : ICommandHandler<GenerateUserDataCommand>
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateUserDataCommand.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateUserDataCommand.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateUserDataCommand
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateUserDataCommandHandler.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/GenerateUserDataCommandHandler.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class GenerateUserDataCommandHandler : ICommandHandler<GenerateUserDataCommand>
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudConfigDriveMetaData.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudConfigDriveMetaData.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     public struct NoCloudConfigDriveMetaData
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudGenerateResultCommandHandler.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudGenerateResultCommandHandler.cs
@@ -1,13 +1,13 @@
 ﻿using System.Dynamic;
 using System.IO;
 using System.Text;
-using Contiva.CloudInit.ConfigDrive.Generator;
+using Haipa.CloudInit.ConfigDrive.Generator;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using YamlDotNet.Serialization;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     internal class NoCloudGenerateResultCommandHandler : ICommandHandler<GenerateResultCommand>
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudGeneratorBuilder.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudGeneratorBuilder.cs
@@ -1,8 +1,8 @@
-﻿using Contiva.CloudInit.ConfigDrive.Generator;
-using Contiva.CloudInit.ConfigDrive.Processing;
+﻿using Haipa.CloudInit.ConfigDrive.Generator;
+using Haipa.CloudInit.ConfigDrive.Processing;
 using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     public class NoCloudGeneratorBuilder : GenerateableBuilder, IProcessableBuilder
     {

--- a/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudGeneratorBuilderExtensions.cs
+++ b/src/CloudInit.ConfigDrive.NoCloud/NoCloud/NoCloudGeneratorBuilderExtensions.cs
@@ -1,6 +1,6 @@
-﻿using Contiva.CloudInit.ConfigDrive.Generator;
+﻿using Haipa.CloudInit.ConfigDrive.Generator;
 
-namespace Contiva.CloudInit.ConfigDrive.NoCloud
+namespace Haipa.CloudInit.ConfigDrive.NoCloud
 {
     public static class NoCloudGeneratorBuilderExtensions
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/CloudInit.ConfigDrive.WindowsImaging.csproj
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/CloudInit.ConfigDrive.WindowsImaging.csproj
@@ -2,18 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
-    <RootNamespace>Contiva.CloudInit.ConfigDrive</RootNamespace>
-    <AssemblyName>Contiva.CloudInit.ConfigDrive.WindowsImaging</AssemblyName>
+    <AssemblyName>Haipa.CloudInit.ConfigDrive.WindowsImaging</AssemblyName>
+    <RootNamespace>Haipa.CloudInit.ConfigDrive</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://github.com/contiva/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/contiva/CloudInit.ConfigDrive</PackageProjectUrl>
-    <Copyright>Contiva</Copyright>
-    <Authors>Contiva</Authors>
-    <Company>Contiva</Company>
-    <Product>Contiva.CloudInit.ConfigDrive</Product>
-    <RepositoryUrl>https://github.com/contiva/CloudInit.ConfigDrive</RepositoryUrl>
-
+    <PackageLicenseUrl>https://github.com/haipa/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/haipa/CloudInit.ConfigDrive</PackageProjectUrl>
+    <Copyright>Haipa Project</Copyright>
+    <Authors>Haipa Project</Authors>
+    <Company>Haipa Project</Company>
+    <Product>Haipa.CloudInit.ConfigDrive</Product>
+    <RepositoryUrl>https://github.com/haipa/CloudInit.ConfigDrive</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudInit.ConfigDrive.WindowsImaging/ImageStream.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/ImageStream.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 
-namespace Contiva.CloudInit.ConfigDrive
+namespace Haipa.CloudInit.ConfigDrive
 {
     /// <summary>
     /// This is a representation of an IO.Stream and IStream object. 

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DDiscFormat2DataEvents.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DDiscFormat2DataEvents.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(4480)]
     [Guid("2735413C-7F64-5B0F-8F00-5D77AFBE261E"), ComImport]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_Events.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_Events.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType((short)0x10), ComVisible(false), ComEventInterface(typeof(DDiscFormat2DataEvents), typeof(DiscFormat2Data_EventsProvider))]
     public interface DiscFormat2Data_Events

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_EventsHandler.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_EventsHandler.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 // ReSharper disable InconsistentNaming
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate void DiscFormat2Data_EventsHandler([In, MarshalAs(UnmanagedType.IDispatch)] object sender, [In, MarshalAs(UnmanagedType.IDispatch)] object args);

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_EventsProvider.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_EventsProvider.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Threading;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [ClassInterface(ClassInterfaceType.None)]
     // ReSharper disable once InconsistentNaming

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_SinkHelper.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/DiscFormat2Data_SinkHelper.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 #pragma warning disable 1584,1711,1572,1581,1580
 #pragma warning disable 1591
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     // Interfaces
 

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/EmulationType.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/EmulationType.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 { 
     [Flags]
     public enum EmulationType

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/FsiFileSystems.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/FsiFileSystems.cs
@@ -4,7 +4,7 @@
 using System;
 
 #pragma warning disable 1591
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [Flags]
     public enum FsiFileSystems

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/FsiItemType.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/FsiItemType.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [Flags]
     public enum FsiItemType

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IBootOptions.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IBootOptions.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices.ComTypes;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscFormat2Data.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscFormat2Data.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices.ComTypes;
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscFormat2DataEventArgs.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscFormat2DataEventArgs.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscMaster2.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscMaster2.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscRecorder2.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscRecorder2.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscRecorder2Ex.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IDiscRecorder2Ex.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 // ReSharper disable UnusedMember.Global
 #pragma warning disable 1584,1711,1572,1581,1580
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("27354132-7F64-5B0F-8F00-5D77AFBE261E")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IEnumFsiItems.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IEnumFsiItems.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("2C941FDA-975B-59BE-A960-9A2A262853A5")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IEnumProgressItems.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IEnumProgressItems.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("2C941FD6-975B-59BE-A960-9A2A262853A5")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFileSystemImage.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFileSystemImage.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [ComImport]
     [TypeLibType(TypeLibTypeFlags.FDual |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFileSystemImageResult.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFileSystemImageResult.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices.ComTypes;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFsiDirectoryItem.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFsiDirectoryItem.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices.ComTypes;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFsiFileItem.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFsiFileItem.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices.ComTypes;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFsiItem.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IFsiItem.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_FEATURE_PAGE_TYPE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_FEATURE_PAGE_TYPE.cs
@@ -1,6 +1,6 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_FEATURE_PAGE_TYPE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_FORMAT2_DATA_MEDIA_STATE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_FORMAT2_DATA_MEDIA_STATE.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_FORMAT2_DATA_MEDIA_STATE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_FORMAT2_DATA_WRITE_ACTION.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_FORMAT2_DATA_WRITE_ACTION.cs
@@ -1,7 +1,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_FORMAT2_DATA_WRITE_ACTION
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MEDIA_PHYSICAL_TYPE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MEDIA_PHYSICAL_TYPE.cs
@@ -1,7 +1,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_MEDIA_PHYSICAL_TYPE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MEDIA_WRITE_PROTECT_STATE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MEDIA_WRITE_PROTECT_STATE.cs
@@ -1,7 +1,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_MEDIA_WRITE_PROTECT_STATE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MODE_PAGE_REQUEST_TYPE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MODE_PAGE_REQUEST_TYPE.cs
@@ -1,7 +1,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_MODE_PAGE_REQUEST_TYPE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MODE_PAGE_TYPE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_MODE_PAGE_TYPE.cs
@@ -1,7 +1,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_MODE_PAGE_TYPE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_PROFILE_TYPE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_PROFILE_TYPE.cs
@@ -1,7 +1,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_PROFILE_TYPE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_READ_TRACK_ADDRESS_TYPE.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IMAPI_READ_TRACK_ADDRESS_TYPE.cs
@@ -1,7 +1,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum IMAPI_READ_TRACK_ADDRESS_TYPE
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IProgressItem.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IProgressItem.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IProgressItems.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/IProgressItems.cs
@@ -5,7 +5,7 @@
 using System.Collections;
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FDual |
                  TypeLibTypeFlags.FDispatchable |

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftBootOptions.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftBootOptions.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [CoClass(typeof(MsftBootOptionsClass)), ComImport]
     [Guid("2C941FD4-975B-59BE-A960-9A2A262853A5")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftBootOptionsClass.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftBootOptionsClass.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FCanCreate)]
     [ClassInterface(ClassInterfaceType.None)]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscFormat2Data.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscFormat2Data.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [CoClass(typeof(MsftDiscFormat2DataClass)), ComImport]
     [Guid("27354153-9F64-5B0F-8F00-5D77AFBE261E")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscFormat2DataClass.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscFormat2DataClass.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FCanCreate)]
     [ClassInterface(ClassInterfaceType.None)]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscMaster2.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscMaster2.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [CoClass(typeof(MsftDiscMaster2Class)), ComImport]
     [Guid("27354130-7F64-5B0F-8F00-5D77AFBE261E")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscMaster2Class.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscMaster2Class.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FCanCreate)]
     [ClassInterface(ClassInterfaceType.None)]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscRecorder2.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscRecorder2.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [CoClass(typeof(MsftDiscRecorder2Class)), ComImport]
     [Guid("27354133-7F64-5B0F-8F00-5D77AFBE261E")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscRecorder2Class.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscRecorder2Class.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FCanCreate)]
     [ClassInterface(ClassInterfaceType.None)]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscRecorder2Ex.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftDiscRecorder2Ex.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [CoClass(typeof(MsftDiscRecorder2Class)), ComImport]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftFileSystemImage.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftFileSystemImage.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [CoClass(typeof(MsftFileSystemImageClass)), ComImport]
     [Guid("2C941FE1-975B-59BE-A960-9A2A262853A5")]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftFileSystemImageClass.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/MsftFileSystemImageClass.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     [TypeLibType(TypeLibTypeFlags.FCanCreate)]
     [ClassInterface(ClassInterfaceType.None)]

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Interop/PlatformId.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Interop/PlatformId.cs
@@ -1,4 +1,4 @@
-namespace Contiva.CloudInit.ConfigDrive.Interop
+namespace Haipa.CloudInit.ConfigDrive.Interop
 {
     public enum PlatformId
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/IsoImageBuilder.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/IsoImageBuilder.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using Contiva.CloudInit.ConfigDrive.Interop;
+using Haipa.CloudInit.ConfigDrive.Interop;
 
 // ReSharper disable UnusedMember.Global
 
-namespace Contiva.CloudInit.ConfigDrive
+namespace Haipa.CloudInit.ConfigDrive
 {
     [ClassInterface(ClassInterfaceType.None)]
     internal sealed class IsoImageBuilder

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Processing/ImageFileProcessResultCommandHandlerDecoration.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Processing/ImageFileProcessResultCommandHandlerDecoration.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace Contiva.CloudInit.ConfigDrive.Processing
+namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     internal class ImageFileProcessResultCommandHandlerDecoration : ICommandHandler<ProcessResultCommand>
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Processing/WindowsImagingProcessorBuilder.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Processing/WindowsImagingProcessorBuilder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Contiva.CloudInit.ConfigDrive.Generator;
-
-namespace Contiva.CloudInit.ConfigDrive.Processing
+﻿namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     public class WindowsImagingProcessorBuilder : ProcessorBuilder
     {

--- a/src/CloudInit.ConfigDrive.WindowsImaging/Processing/WindowsImagingProcessorBuilderExtensions.cs
+++ b/src/CloudInit.ConfigDrive.WindowsImaging/Processing/WindowsImagingProcessorBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive.Processing
+﻿namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     public static class WindowsImagingProcessorBuilderExtensions
     {

--- a/src/CloudInit.ConfigDrive/CloudInit.ConfigDrive.csproj
+++ b/src/CloudInit.ConfigDrive/CloudInit.ConfigDrive.csproj
@@ -2,17 +2,18 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <AssemblyName>Contiva.CloudInit.ConfigDrive</AssemblyName>
-    <RootNamespace>Contiva.CloudInit.ConfigDrive</RootNamespace>
+    <AssemblyName>Haipa.CloudInit.ConfigDrive</AssemblyName>
+    <RootNamespace>Haipa.CloudInit.ConfigDrive</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://github.com/contiva/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/contiva/CloudInit.ConfigDrive</PackageProjectUrl>
-    <Copyright>Contiva</Copyright>
-    <Authors>Contiva</Authors>
-    <Company>Contiva</Company>
-    <Product>Contiva.CloudInit.ConfigDrive</Product>
-    <RepositoryUrl>https://github.com/contiva/CloudInit.ConfigDrive</RepositoryUrl>
+    <PackageLicenseUrl>https://github.com/haipa/CloudInit.ConfigDrive/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/haipa/CloudInit.ConfigDrive</PackageProjectUrl>
+    <Copyright>Haipa Project</Copyright>
+    <Authors>Haipa Project</Authors>
+    <Company>Haipa Project</Company>
+    <Product>Haipa.CloudInit.ConfigDrive</Product>
+    <RepositoryUrl>https://github.com/haipa/CloudInit.ConfigDrive</RepositoryUrl>
+    <PackageId>Haipa.CloudInit.ConfigDrive</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CloudInit.ConfigDrive/Generator/ConfigDriveGenerator.cs
+++ b/src/CloudInit.ConfigDrive/Generator/ConfigDriveGenerator.cs
@@ -1,6 +1,6 @@
-﻿using Contiva.CloudInit.ConfigDrive.Processing;
+﻿using Haipa.CloudInit.ConfigDrive.Processing;
 
-namespace Contiva.CloudInit.ConfigDrive.Generator
+namespace Haipa.CloudInit.ConfigDrive.Generator
 {
     class ConfigDriveGenerator : IConfigDriveGenerator
     {

--- a/src/CloudInit.ConfigDrive/Generator/GeneratorBuilder.cs
+++ b/src/CloudInit.ConfigDrive/Generator/GeneratorBuilder.cs
@@ -1,8 +1,7 @@
-﻿
-using Contiva.CloudInit.ConfigDrive.Injection;
-using Contiva.CloudInit.ConfigDrive.Processing;
+﻿using Haipa.CloudInit.ConfigDrive.Injection;
+using Haipa.CloudInit.ConfigDrive.Processing;
 
-namespace Contiva.CloudInit.ConfigDrive.Generator
+namespace Haipa.CloudInit.ConfigDrive.Generator
 {
 
     public class GeneratorBuilder : GenerateableBuilder

--- a/src/CloudInit.ConfigDrive/Processing/ProcessingBuilderExtensions.cs
+++ b/src/CloudInit.ConfigDrive/Processing/ProcessingBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Contiva.CloudInit.ConfigDrive.Processing
+﻿namespace Haipa.CloudInit.ConfigDrive.Processing
 {
     public static class ProcessingBuilderExtensions
     {

--- a/src/GenConfigDrive/GenConfigDrive.csproj
+++ b/src/GenConfigDrive/GenConfigDrive.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net471</TargetFramework>
-    <RootNamespace>Contiva.CloudInit.ConfigDrive</RootNamespace>
+    <RootNamespace>Haipa.CloudInit.ConfigDrive</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GenConfigDrive/Program.cs
+++ b/src/GenConfigDrive/Program.cs
@@ -2,12 +2,12 @@
 using System.IO;
 using System.Text;
 using CommandLine;
-using Contiva.CloudInit.ConfigDrive.Generator;
-using Contiva.CloudInit.ConfigDrive.NoCloud;
-using Contiva.CloudInit.ConfigDrive.Processing;
+using Haipa.CloudInit.ConfigDrive.Generator;
+using Haipa.CloudInit.ConfigDrive.NoCloud;
+using Haipa.CloudInit.ConfigDrive.Processing;
 using Newtonsoft.Json.Linq;
 
-namespace Contiva.CloudInit.ConfigDrive
+namespace Haipa.CloudInit.ConfigDrive
 {
     class Program
     {


### PR DESCRIPTION
CloudInit.ConfigDrive will be managed by Haipa project in future. Renamed all occurrences of Contiva to Haipa