### PR TITLE
Fix multipart user-data MIME framing

### DIFF
--- a/src/CloudInit.ConfigDrive.Core/UserDataSerializer.cs
+++ b/src/CloudInit.ConfigDrive.Core/UserDataSerializer.cs
@@ -16,9 +16,12 @@ namespace Dbosoft.CloudInit.ConfigDrive
             sb.Append("From nobody Fri Jan  11 07:00:00 1980\n");
             sb.Append("Content-Type: multipart/mixed; boundary=\"==BOUNDARY==\"\n");
             sb.Append("MIME-Version: 1.0\n");
+            sb.Append("\n");
 
+            var hasParts = false;
             foreach (var data in userData)
             {
+                hasParts = true;
                 sb.Append("--==BOUNDARY==\n");
                 sb.Append("MIME-Version: 1.0\n");
 
@@ -37,10 +40,17 @@ namespace Dbosoft.CloudInit.ConfigDrive
                     sb.Append("Content-Transfer-Encoding: base64\n");
                 }
 
+                sb.Append("\n");
                 sb.Append(contentString+ "\n");
 
 
             }
+
+            // Only emit the RFC 2046 close delimiter when at least one part was
+            // written; a lone "--==BOUNDARY==--" with no opening boundary would be
+            // a malformed multipart body.
+            if (hasParts)
+                sb.Append("--==BOUNDARY==--\n");
 
             if (!options.GZip)
                 return new MemoryStream(Encoding.ASCII.GetBytes(sb.ToString()));

--- a/src/CloudInit.ConfigDrive.Core/UserDataSerializer.cs
+++ b/src/CloudInit.ConfigDrive.Core/UserDataSerializer.cs
@@ -41,7 +41,8 @@ namespace Dbosoft.CloudInit.ConfigDrive
                 }
 
                 sb.Append("\n");
-                sb.Append(contentString+ "\n");
+                sb.Append(contentString);
+                sb.Append('\n');
 
 
             }

--- a/test/CloudInit.ConfigDrive.Core.Test/CloudInit.ConfigDrive.Core.Test.csproj
+++ b/test/CloudInit.ConfigDrive.Core.Test/CloudInit.ConfigDrive.Core.Test.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MimeKit" Version="4.16.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">

--- a/test/CloudInit.ConfigDrive.Core.Test/UserDataSerializerTests.cs
+++ b/test/CloudInit.ConfigDrive.Core.Test/UserDataSerializerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Dbosoft.CloudInit.ConfigDrive;
+using MimeKit;
 using Xunit;
 
 namespace CloudInit.ConfigDrive.Core.Test;
@@ -29,6 +30,7 @@ public class UserDataSerializerTests
         Assert.Equal(@"From nobody Fri Jan  11 07:00:00 1980
 Content-Type: multipart/mixed; boundary=""==BOUNDARY==""
 MIME-Version: 1.0
+
 ".Replace("\r\n", "\n"), act);
     }
 
@@ -55,10 +57,13 @@ MIME-Version: 1.0
         Assert.Equal(@"From nobody Fri Jan  11 07:00:00 1980
 Content-Type: multipart/mixed; boundary=""==BOUNDARY==""
 MIME-Version: 1.0
+
 --==BOUNDARY==
 MIME-Version: 1.0
 Content-Type: text/cloud-config; charset=""us-ascii""
+
 some config
+--==BOUNDARY==--
 ".Replace("\r\n", "\n"), act);
     }
 
@@ -85,11 +90,14 @@ some config
         Assert.Equal(@$"From nobody Fri Jan  11 07:00:00 1980
 Content-Type: multipart/mixed; boundary=""==BOUNDARY==""
 MIME-Version: 1.0
+
 --==BOUNDARY==
 MIME-Version: 1.0
 Content-Type: text/cloud-config; charset=""us-ascii""
 Content-Transfer-Encoding: base64
+
 {Convert.ToBase64String(Encoding.ASCII.GetBytes("some config"), Base64FormattingOptions.InsertLineBreaks)}
+--==BOUNDARY==--
 ".Replace("\r\n", "\n"), act);
 
     }
@@ -118,8 +126,81 @@ Content-Transfer-Encoding: base64
         Assert.Equal(@"From nobody Fri Jan  11 07:00:00 1980
 Content-Type: multipart/mixed; boundary=""==BOUNDARY==""
 MIME-Version: 1.0
+
 ".Replace("\r\n", "\n"), act);
 
+    }
+
+    [Fact]
+    public async Task EndsWithCloseDelimiter()
+    {
+        var serializer = new UserDataSerializer();
+
+        await using var resultStream =
+            await serializer.SerializeUserData(
+                new[]
+                {
+                    new UserData(UserDataContentType.CloudConfig, "some config", Encoding.ASCII)
+                }, new UserDataOptions
+                {
+                    Base64Encode = false,
+                    GZip = false
+                });
+
+        using var reader = new StreamReader(resultStream);
+        var act = await reader.ReadToEndAsync();
+
+        Assert.EndsWith("--==BOUNDARY==--\n", act);
+    }
+
+    [Fact]
+    public async Task RoundTripsThroughMimeParserWithoutDroppingParts()
+    {
+        var serializer = new UserDataSerializer();
+
+        await using var resultStream =
+            await serializer.SerializeUserData(
+                new[]
+                {
+                    new UserData(UserDataContentType.CloudConfig, "#cloud-config\nfoo: bar", Encoding.ASCII)
+                }, new UserDataOptions
+                {
+                    Base64Encode = false,
+                    GZip = false
+                });
+
+        var message = await MimeMessage.LoadAsync(resultStream);
+        var multipart = Assert.IsType<Multipart>(message.Body);
+
+        Assert.Single(multipart);
+        var part = Assert.IsType<TextPart>(multipart[0]);
+        Assert.Equal("text/cloud-config", part.ContentType.MimeType);
+        Assert.Equal("#cloud-config\nfoo: bar", part.Text.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public async Task RoundTripsBodyWithColonFirstLine()
+    {
+        var serializer = new UserDataSerializer();
+
+        // A body whose first line contains a colon must not be mistaken for a header.
+        await using var resultStream =
+            await serializer.SerializeUserData(
+                new[]
+                {
+                    new UserData(UserDataContentType.CloudConfig, "foo: bar\nbaz: qux", Encoding.ASCII)
+                }, new UserDataOptions
+                {
+                    Base64Encode = false,
+                    GZip = false
+                });
+
+        var message = await MimeMessage.LoadAsync(resultStream);
+        var multipart = Assert.IsType<Multipart>(message.Body);
+
+        Assert.Single(multipart);
+        var part = Assert.IsType<TextPart>(multipart[0]);
+        Assert.Equal("foo: bar\nbaz: qux", part.Text.Replace("\r\n", "\n"));
     }
 
 }


### PR DESCRIPTION
The multipart/mixed user-data produced by `UserDataSerializer` was missing the RFC 2046 close delimiter (`--==BOUNDARY==--`). Strict MIME parsers treated the final part as unterminated and dropped it — with a single cloud-config part the entire payload was silently lost.

Changes:
- Append the close delimiter after the parts, but only when at least one part was written (no orphan delimiter for empty input).
- Add the blank line between the container headers and the body, and between each part's headers and its body, so a body whose first line contains a colon is not mis-parsed as a header. This matches cloud-init's own output.
- Add MimeKit-based round-trip tests confirming parts survive a spec-conformant parser, and update existing assertions.